### PR TITLE
Fix FILTER_FLAG_NO_RES_RANGE flag

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -933,7 +933,7 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 						&& ip[4] == 0 && ip[5] == 0 && ip[6] == 0 && (ip[7] == 0 || ip[7] == 1))
 						|| (ip[0] == 0x5f)
 						|| (ip[0] >= 0xfe80 && ip[0] <= 0xfebf)
-						|| ((ip[0] == 0x2001 && ip[1] == 0x0db8) || (ip[1] >= 0x0010 && ip[1] <= 0x001f))
+						|| (ip[0] == 0x2001 && (ip[1] == 0x0db8 || (ip[1] >= 0x0010 && ip[1] <= 0x001f)))
 						|| (ip[0] == 0x3ff3)
 					) {
 						RETURN_VALIDATION_FAILED


### PR DESCRIPTION
`2001:10::/28` is a reversed IPv6 range. But there's a typo in #7476, which caused IPv6 address like `240b:0010::1` will be filtered by the flag `FILTER_FLAG_NO_RES_RANGE`.

http://www.faqs.org/rfcs/rfc6890.html